### PR TITLE
Update README.md - add Sample AA plugin

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -35,6 +35,7 @@ Increase the value you get from One Identity products by leveraging the power of
 |  | [RADIUS MFA](https://github.com/OneIdentity/safeguard-sessions-plugin-radius-mfa) |  |
 |  | [ServiceNow](https://github.com/OneIdentity/safeguard-sessions-plugin-servicenow) |  |
 |  | [Yubikey MFA](https://github.com/OneIdentity/safeguard-sessions-plugin-yubikey-mfa) |  |
+|  | [Shared Sessions Sample](https://github.com/OneIdentity/safeguard-sessions-plugin-sample-aa-plugin-for-shared-sessions) |  |
 
 ### Safeguard Authentication Services
 - [Ansible](https://github.com/OneIdentity/ansible-authentication-services)


### PR DESCRIPTION
We have created a Sample AA plugin for demonstrating how to do gateway authentication via custom plugin for SPS-initiated sessions using SPP as credential store.
I would like to add this plugin's link to the table in the main readme.